### PR TITLE
Simplify generate_new_token(...) usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,7 @@ SECRET_KEY = 'super-secret-string'
 token_generator = PasswordResetTokenGenerator(SECRET_KEY)
 
 # Generate PasswordResetToken instance with custom payload.
-token = token_generator.generate_new_token({
-    "sub": "vremes"
-})
+token = token_generator.generate_new_token('vremes')
 
 # >> PasswordResetToken(json_web_token='eyJ0eXAiOiJKV1QiLCJhbGci...', secret='super-secret-string', algorithm='HS256')
 print(token)
@@ -29,10 +27,10 @@ token_payload = token.get_payload()
 print(token_payload)
 
 # Who does this token belong to?
-token_subject = token_payload.get('sub')
+user_identifier = token_payload.get_user_identifier()
 
 # >> vremes
-print(token_subject)
+print(user_identifier)
 
 # Is this token expired?
 token_is_expired = token.is_expired()
@@ -47,9 +45,7 @@ from password_reset_token import PasswordResetToken
 
 SECRET_KEY = 'super-secret-string'
 
-json_web_token = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ2cmVtZXMiLCJleHAiOjE2NjAzOTY3MjR9.F8bHjTCnw46SoCU9LzqCIpmW9tv4Uhtp5NAZUKIotIM'
-
-token = PasswordResetToken(json_web_token, SECRET_KEY)
+token = PasswordResetToken('eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ2cmVtZXMiLCJleHAiOjE2NjAzOTY3MjR9.F8bHjTCnw46SoCU9LzqCIpmW9tv4Uhtp5NAZUKIotIM', SECRET_KEY)
 
 # >> PasswordResetToken(json_web_token='eyJ0eXAiOiJKV1QiLCJhbGci...', secret='super-secret-string', algorithm='HS256')
 print(token)

--- a/password_reset_token/token.py
+++ b/password_reset_token/token.py
@@ -1,4 +1,5 @@
 from time import time
+from functools import lru_cache
 from dataclasses import dataclass
 
 from .defaults import JWT_DEFAULT_ALGORITHM, JWT_DEFAULT_EXPIRATION_TIME_SECONDS
@@ -12,6 +13,7 @@ class PasswordResetToken:
     secret: str
     algorithm: str = JWT_DEFAULT_ALGORITHM
 
+    @lru_cache(maxsize=1)
     def get_payload(self) -> dict:
         """Returns the payload for this token as a dict."""
         try:
@@ -29,9 +31,13 @@ class PasswordResetToken:
         except (jwt.exceptions.ExpiredSignatureError, jwt.exceptions.DecodeError):
             return True
 
+    def get_user_identifier(self) -> int | str | None:
+        """Returns user identifier (sub) from this token, this method is a shortcut for `get_payload().get('sub')`."""
+        return self.get_payload().get('sub')
+
     def __decode_jwt(self) -> dict:
         return jwt.decode(self.json_web_token, self.secret, self.algorithm, options={
-            "require": ["exp"]
+            "require": ["exp", "sub"]
         })
 
 class PasswordResetTokenGenerator:
@@ -40,17 +46,20 @@ class PasswordResetTokenGenerator:
         self.secret = secret
         self.algorithm = algorithm
 
-    def generate_new_token(self, payload: dict, exp: int = 0) -> PasswordResetToken:
+    def generate_new_token(self, user_identifier: int | str, additional_claims: dict = {}) -> PasswordResetToken:
         """Generates PasswordResetToken instance for you using given arguments."""
-        exp = int(exp)
-        use_default_expiration_time = exp == 0
+        jwt_payload = {}
+        jwt_payload.update(additional_claims)
 
-        if use_default_expiration_time:
+        exp = additional_claims.get('exp')
+
+        if exp is None:
             exp = int(time()) + JWT_DEFAULT_EXPIRATION_TIME_SECONDS
 
-        payload.update({
+        jwt_payload.update({
+            "sub": user_identifier,
             "exp": exp
         })
 
-        json_web_token = jwt.encode(payload, self.secret, self.algorithm)
+        json_web_token = jwt.encode(jwt_payload, self.secret, self.algorithm)
         return PasswordResetToken(json_web_token, self.secret, self.algorithm)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="password_reset_token",
-    version="0.0.3",
+    version="0.0.4",
     author="Valtteri Remes",
     description="Simple and easy to use Python 3 module to generate password reset tokens, based on JWT.",
     long_description=long_description,

--- a/tests.py
+++ b/tests.py
@@ -1,60 +1,45 @@
 import unittest
+from uuid import uuid4
 from dataclasses import FrozenInstanceError
 
 from password_reset_token import PasswordResetTokenGenerator, PasswordResetToken
 
 SECRET_KEY_FOR_TESTS = 'test'
+GENERATOR = PasswordResetTokenGenerator(SECRET_KEY_FOR_TESTS)
+USER_IDENTIFIER = str(uuid4())
 
 class TestPasswordResetToken(unittest.TestCase):
 
     def test_password_reset_token_generator(self):
-        generator = PasswordResetTokenGenerator(SECRET_KEY_FOR_TESTS)
-
-        token = generator.generate_new_token({
-            "hello": "world"
-        })
+        token = GENERATOR.generate_new_token(USER_IDENTIFIER)
 
         self.assertIsInstance(token, PasswordResetToken)
 
     def test_token_immutability(self):
-        generator = PasswordResetTokenGenerator(SECRET_KEY_FOR_TESTS)
-
-        token = generator.generate_new_token({
-            "hello": "world"
-        })
+        token = GENERATOR.generate_new_token(USER_IDENTIFIER)
 
         with self.assertRaises(FrozenInstanceError):
             token.json_web_token = 'test'
 
     def test_expired_token(self):
-        expired_token = PasswordResetToken('eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiZXhwIjoxNjYwMzg5MzQ0fQ.nVskhnaRfMsbZVwJ5O5R6PQoiv9O2QZlZrSRpNQb75s', SECRET_KEY_FOR_TESTS)
+        expired_token = PasswordResetToken('eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI0ZTcxMDUyYS04YjNjLTQ4NmMtYTNhYi0yZmRlMTBiOTFlMGUiLCJleHAiOjE2NjA0ODYxNDJ9.lnSV4bzW4u0J0fiZIAEAi0V6NEAEKubzQImm3UvLB5Y', SECRET_KEY_FOR_TESTS)
         self.assertTrue(expired_token.is_expired())
 
     def test_fresh_token(self):
-        generator = PasswordResetTokenGenerator(SECRET_KEY_FOR_TESTS)
-
-        token = generator.generate_new_token({
-            "hello": "world"
-        })
+        token = GENERATOR.generate_new_token(USER_IDENTIFIER)
 
         self.assertFalse(token.is_expired())
 
     def test_token_payload(self):
-        generator = PasswordResetTokenGenerator(SECRET_KEY_FOR_TESTS)
-
-        token = generator.generate_new_token({
-            "hello": "world"
-        })
+        token = GENERATOR.generate_new_token(USER_IDENTIFIER)
 
         token_payload = token.get_payload()
 
         self.assertIsInstance(token_payload, dict)
 
-        token_payload_hello = token_payload.get('hello')
+        token_user_identifier = token.get_user_identifier()
 
-        self.assertIsNotNone(token_payload_hello)
-
-        self.assertTrue(token_payload_hello == 'world')
+        self.assertTrue(token_user_identifier == USER_IDENTIFIER)
 
         token_missing_key = token_payload.get('does-not-exist')
 
@@ -81,6 +66,22 @@ class TestPasswordResetToken(unittest.TestCase):
         token_expired = token.is_expired()
 
         self.assertTrue(token_expired)
+
+    def test_token_additional_claims(self):
+        token = GENERATOR.generate_new_token(USER_IDENTIFIER, {
+            "my-custom-claim": "custom-claim-value",
+            "sub": "conflicting-sub"
+        })
+
+        token_payload = token.get_payload()
+
+        self.assertTrue(token_payload.get('sub') == USER_IDENTIFIER)
+        self.assertTrue(token_payload.get('my-custom-claim') == 'custom-claim-value')
+
+    def test_multiple_tokens(self):
+        for uid in range(0, 10):
+            token = GENERATOR.generate_new_token(uid)
+            self.assertTrue(token.get_user_identifier() == uid)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- `generate_new_token` now takes `user_identifier` as first parameter instead of `dict`.
- Added `get_user_identifier()` method to `PasswordResetToken` which returns the value of `sub` claim.